### PR TITLE
bin scripts style & portability

### DIFF
--- a/bin/arbshell
+++ b/bin/arbshell
@@ -1,6 +1,6 @@
 #!/bin/sh 
 
-BASEDIR=$(dirname $(dirname $(readlink -f $0)))
+BASEDIR=$(dirname $(dirname $(realpath $0)))
 
 CLASSPATH=$(cat $BASEDIR/class.path):$BASEDIR/target/site/apidocs
 

--- a/bin/arbshell
+++ b/bin/arbshell
@@ -2,6 +2,6 @@
 
 BASEDIR=$(dirname $(dirname $(readlink -f $0)))
 
-CLASSPATH=`cat $BASEDIR/class.path`:$BASEDIR/target/site/apidocs
+CLASSPATH=$(cat $BASEDIR/class.path):$BASEDIR/target/site/apidocs
 
 LD_LIBRARY_PATH=$BASEDIR jshell --enable-native-access --enable-preview -J-ea --class-path $CLASSPATH:$BASEDIR/target/classes --startup $BASEDIR/shell.start

--- a/bin/arbshell
+++ b/bin/arbshell
@@ -1,7 +1,7 @@
 #!/bin/sh 
 
-BASEDIR=$(dirname "$(dirname "$(realpath "$0")")")
+basedir=$(dirname "$(dirname "$(realpath "$0")")")
 
-CLASSPATH=$(cat "$BASEDIR"/class.path):"$BASEDIR"/target/site/apidocs
+classpath=$(cat "$basedir"/class.path):"$basedir"/target/site/apidocs
 
-LD_LIBRARY_PATH="$BASEDIR" jshell --enable-native-access --enable-preview -J-ea --class-path "$CLASSPATH":"$BASEDIR"/target/classes --startup "$BASEDIR"/shell.start
+LD_LIBRARY_PATH="$basedir" jshell --enable-native-access --enable-preview -J-ea --class-path "$classpath":"$basedir"/target/classes --startup "$basedir"/shell.start

--- a/bin/arbshell
+++ b/bin/arbshell
@@ -1,6 +1,6 @@
 #!/bin/sh 
 
-BASEDIR=$(dirname $(readlink -f $0))/..
+BASEDIR=$(dirname $(dirname $(readlink -f $0)))
 
 CLASSPATH=`cat $BASEDIR/class.path`:$BASEDIR/target/site/apidocs
 

--- a/bin/arbshell
+++ b/bin/arbshell
@@ -1,7 +1,7 @@
 #!/bin/sh 
 
-BASEDIR=$(dirname $(dirname $(realpath $0)))
+BASEDIR=$(dirname "$(dirname "$(realpath "$0")")")
 
-CLASSPATH=$(cat $BASEDIR/class.path):$BASEDIR/target/site/apidocs
+CLASSPATH=$(cat "$BASEDIR"/class.path):"$BASEDIR"/target/site/apidocs
 
-LD_LIBRARY_PATH=$BASEDIR jshell --enable-native-access --enable-preview -J-ea --class-path $CLASSPATH:$BASEDIR/target/classes --startup $BASEDIR/shell.start
+LD_LIBRARY_PATH="$BASEDIR" jshell --enable-native-access --enable-preview -J-ea --class-path "$CLASSPATH":"$BASEDIR"/target/classes --startup "$BASEDIR"/shell.start

--- a/bin/arbshell
+++ b/bin/arbshell
@@ -1,12 +1,7 @@
 #!/bin/sh 
 
-
 BASEDIR=$(dirname $(readlink -f $0))/..
+
 CLASSPATH=`cat $BASEDIR/class.path`:$BASEDIR/target/site/apidocs
 
 LD_LIBRARY_PATH=$BASEDIR jshell --enable-native-access --enable-preview -J-ea --class-path $CLASSPATH:$BASEDIR/target/classes --startup $BASEDIR/shell.start
-
-
-
-
-

--- a/bin/build
+++ b/bin/build
@@ -1,9 +1,13 @@
 #!/bin/sh
 
 BASEDIR=$(dirname $(readlink -f $0))/..
+
 cd $BASEDIR
 
 gaw
+
 mvn install
+
 updateJavadocs
+
 updateClasspath

--- a/bin/build
+++ b/bin/build
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-BASEDIR=$(dirname $(dirname $(realpath $0)))
+BASEDIR=$(dirname "$(dirname "$(realpath "$0")")")
 
-cd $BASEDIR
+cd "$BASEDIR"
 
 gaw
 

--- a/bin/build
+++ b/bin/build
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-BASEDIR=$(dirname $(dirname $(readlink -f $0)))
+BASEDIR=$(dirname $(dirname $(realpath $0)))
 
 cd $BASEDIR
 

--- a/bin/build
+++ b/bin/build
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-BASEDIR=$(dirname $(readlink -f $0))/..
+BASEDIR=$(dirname $(dirname $(readlink -f $0)))
 
 cd $BASEDIR
 

--- a/bin/build
+++ b/bin/build
@@ -2,7 +2,7 @@
 
 basedir=$(dirname "$(dirname "$(realpath "$0")")")
 
-cd "$basedir"
+cd "$basedir" || exit
 
 gaw
 

--- a/bin/build
+++ b/bin/build
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-BASEDIR=$(dirname "$(dirname "$(realpath "$0")")")
+basedir=$(dirname "$(dirname "$(realpath "$0")")")
 
-cd "$BASEDIR"
+cd "$basedir"
 
 gaw
 

--- a/bin/enumeratePackages
+++ b/bin/enumeratePackages
@@ -1,5 +1,3 @@
 #!/bin/sh
 
 find src/ -type d | sed -e 's/\//./g' | cut -c5- | grep -v doc-files | xargs -n 1 -I P echo exports P\;
-
-

--- a/bin/grindvals
+++ b/bin/grindvals
@@ -2,6 +2,6 @@
 
 basedir=$(dirname "$(dirname "$(realpath "$0")")")
 
-cd "$basedir"
+cd "$basedir" || exit
 
 valgrind --leak-check=full --show-leak-kinds=all --suppressions=valgrind.suppress --log-file=valgrind.log -v "$@"

--- a/bin/grindvals
+++ b/bin/grindvals
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
-BASEDIR=$(dirname $(dirname $(realpath $0)))
+BASEDIR=$(dirname "$(dirname "$(realpath "$0")")")
 
-cd $BASEDIR
+cd "$BASEDIR"
 
-valgrind --leak-check=full --show-leak-kinds=all --suppressions=valgrind.suppress --log-file=valgrind.log -v $@
+valgrind --leak-check=full --show-leak-kinds=all --suppressions=valgrind.suppress --log-file=valgrind.log -v "$@"

--- a/bin/grindvals
+++ b/bin/grindvals
@@ -1,6 +1,6 @@
 #!/bin/sh -x
 
-BASEDIR=$(dirname $(dirname $(readlink -f $0)))
+BASEDIR=$(dirname $(dirname $(realpath $0)))
 
 cd $BASEDIR
 

--- a/bin/grindvals
+++ b/bin/grindvals
@@ -1,7 +1,7 @@
 #!/bin/sh -x
 
-BASEDIR=$(dirname "$(dirname "$(realpath "$0")")")
+basedir=$(dirname "$(dirname "$(realpath "$0")")")
 
-cd "$BASEDIR"
+cd "$basedir"
 
 valgrind --leak-check=full --show-leak-kinds=all --suppressions=valgrind.suppress --log-file=valgrind.log -v "$@"

--- a/bin/grindvals
+++ b/bin/grindvals
@@ -1,6 +1,7 @@
 #!/bin/sh -x
 
 BASEDIR=$(dirname $(readlink -f $0))/..
+
 cd $BASEDIR
 
 valgrind --leak-check=full --show-leak-kinds=all --suppressions=valgrind.suppress --log-file=valgrind.log -v $@

--- a/bin/grindvals
+++ b/bin/grindvals
@@ -1,6 +1,6 @@
 #!/bin/sh -x
 
-BASEDIR=$(dirname $(readlink -f $0))/..
+BASEDIR=$(dirname $(dirname $(readlink -f $0)))
 
 cd $BASEDIR
 

--- a/bin/lookup
+++ b/bin/lookup
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-dict $@ 2>&1 | tee ~/words/$@.txt
+dict "$@" 2>&1 | tee ~/words/"$@".txt

--- a/bin/lookup
+++ b/bin/lookup
@@ -1,6 +1,10 @@
 #!/bin/sh
 
+d=${HOME}/words
+
+mkdir -p "$d"
+
 for word in "$@"
 do
-    dict "$word" 2>&1 | tee ~/words/"$word".txt
+    2>&1 dict "$word" | tee "$d"/"$word".txt
 done

--- a/bin/lookup
+++ b/bin/lookup
@@ -1,3 +1,6 @@
 #!/bin/sh
 
-dict "$@" 2>&1 | tee ~/words/"$@".txt
+for word in "$@"
+do
+    dict "$word" 2>&1 | tee ~/words/"$word".txt
+done

--- a/bin/run
+++ b/bin/run
@@ -1,7 +1,7 @@
 #!/bin/sh 
 
-BASEDIR=$(dirname "$(dirname "$(realpath "$0")")")
+basedir=$(dirname "$(dirname "$(realpath "$0")")")
 
-CLASSPATH=$(cat "$BASEDIR"/class.path)
+classpath=$(cat "$basedir"/class.path)
 
-LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 java --enable-preview -Djava.library.path="$BASEDIR" -ea -classpath "$CLASSPATH":"$BASEDIR"/target/classes "$@"
+ld_preload=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 java --enable-preview -Djava.library.path="$basedir" -ea -classpath "$classpath":"$basedir"/target/classes "$@"

--- a/bin/run
+++ b/bin/run
@@ -1,9 +1,7 @@
 #!/bin/sh 
 
-
 BASEDIR=$(dirname $(readlink -f $0))/..
+
 CLASSPATH=`cat $BASEDIR/class.path`
+
 LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 java --enable-preview -Djava.library.path=$BASEDIR -ea -classpath $CLASSPATH:$BASEDIR/target/classes $@
-
-
-

--- a/bin/run
+++ b/bin/run
@@ -1,6 +1,6 @@
 #!/bin/sh 
 
-BASEDIR=$(dirname $(readlink -f $0))/..
+BASEDIR=$(dirname $(dirname $(readlink -f $0)))
 
 CLASSPATH=`cat $BASEDIR/class.path`
 

--- a/bin/run
+++ b/bin/run
@@ -2,6 +2,6 @@
 
 BASEDIR=$(dirname $(dirname $(readlink -f $0)))
 
-CLASSPATH=`cat $BASEDIR/class.path`
+CLASSPATH=$(cat $BASEDIR/class.path)
 
 LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 java --enable-preview -Djava.library.path=$BASEDIR -ea -classpath $CLASSPATH:$BASEDIR/target/classes $@

--- a/bin/run
+++ b/bin/run
@@ -1,7 +1,7 @@
 #!/bin/sh 
 
-BASEDIR=$(dirname $(dirname $(realpath $0)))
+BASEDIR=$(dirname "$(dirname "$(realpath "$0")")")
 
-CLASSPATH=$(cat $BASEDIR/class.path)
+CLASSPATH=$(cat "$BASEDIR"/class.path)
 
-LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 java --enable-preview -Djava.library.path=$BASEDIR -ea -classpath $CLASSPATH:$BASEDIR/target/classes $@
+LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 java --enable-preview -Djava.library.path="$BASEDIR" -ea -classpath "$CLASSPATH":"$BASEDIR"/target/classes "$@"

--- a/bin/run
+++ b/bin/run
@@ -1,6 +1,6 @@
 #!/bin/sh 
 
-BASEDIR=$(dirname $(dirname $(readlink -f $0)))
+BASEDIR=$(dirname $(dirname $(realpath $0)))
 
 CLASSPATH=$(cat $BASEDIR/class.path)
 

--- a/bin/runWithLeakCheck
+++ b/bin/runWithLeakCheck
@@ -1,9 +1,9 @@
 #!/bin/sh -x
 
-BASEDIR=$(dirname "$(dirname "$(realpath "$0")")")
+basedir=$(dirname "$(dirname "$(realpath "$0")")")
 
-CLASSPATH=$(cat "$BASEDIR"/class.path)
+classpath=$(cat "$basedir"/class.path)
 
-ARGS='-ea --enable-preview --enable-native-access=arb4j --add-modules=javafx.graphics --add-reads javafx.graphics=ALL-UNNAMED --add-opens javafx.controls/com.sun.javafx.charts=ALL-UNNAMED --add-opens javafx.controls/com.sun.javafx.scene.control.inputmap=ALL-UNNAMED --add-opens javafx.graphics/com.sun.javafx.iio=ALL-UNNAMED --add-opens javafx.graphics/com.sun.javafx.iio.common=ALL-UNNAMED --add-opens javafx.graphics/com.sun.javafx.css=ALL-UNNAMED --add-opens javafx.base/com.sun.javafx.runtime=ALL-UNNAMED --add-exports javafx.controls/com.sun.javafx.scene.control.behavior=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.scene.traversal=ALL-UNNAMED'
+args='-ea --enable-preview --enable-native-access=arb4j --add-modules=javafx.graphics --add-reads javafx.graphics=ALL-UNNAMED --add-opens javafx.controls/com.sun.javafx.charts=ALL-UNNAMED --add-opens javafx.controls/com.sun.javafx.scene.control.inputmap=ALL-UNNAMED --add-opens javafx.graphics/com.sun.javafx.iio=ALL-UNNAMED --add-opens javafx.graphics/com.sun.javafx.iio.common=ALL-UNNAMED --add-opens javafx.graphics/com.sun.javafx.css=ALL-UNNAMED --add-opens javafx.base/com.sun.javafx.runtime=ALL-UNNAMED --add-exports javafx.controls/com.sun.javafx.scene.control.behavior=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.scene.traversal=ALL-UNNAMED'
 
-grindvals $ARGS -Djava.library.path="$BASEDIR" -classpath "$CLASSPATH":"$BASEDIR"/target/classes "$@"
+grindvals $args -Djava.library.path="$basedir" -classpath "$classpath":"$basedir"/target/classes "$@"

--- a/bin/runWithLeakCheck
+++ b/bin/runWithLeakCheck
@@ -2,7 +2,7 @@
 
 BASEDIR=$(dirname $(dirname $(readlink -f $0)))
 
-CLASSPATH=`cat $BASEDIR/class.path`
+CLASSPATH=$(cat $BASEDIR/class.path)
 
 ARGS='-ea --enable-preview --enable-native-access=arb4j --add-modules=javafx.graphics --add-reads javafx.graphics=ALL-UNNAMED --add-opens javafx.controls/com.sun.javafx.charts=ALL-UNNAMED --add-opens javafx.controls/com.sun.javafx.scene.control.inputmap=ALL-UNNAMED --add-opens javafx.graphics/com.sun.javafx.iio=ALL-UNNAMED --add-opens javafx.graphics/com.sun.javafx.iio.common=ALL-UNNAMED --add-opens javafx.graphics/com.sun.javafx.css=ALL-UNNAMED --add-opens javafx.base/com.sun.javafx.runtime=ALL-UNNAMED --add-exports javafx.controls/com.sun.javafx.scene.control.behavior=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.scene.traversal=ALL-UNNAMED'
 

--- a/bin/runWithLeakCheck
+++ b/bin/runWithLeakCheck
@@ -3,9 +3,7 @@
 BASEDIR=$(dirname $(readlink -f $0))/..
 
 CLASSPATH=`cat $BASEDIR/class.path`
+
 ARGS='-ea --enable-preview --enable-native-access=arb4j --add-modules=javafx.graphics --add-reads javafx.graphics=ALL-UNNAMED --add-opens javafx.controls/com.sun.javafx.charts=ALL-UNNAMED --add-opens javafx.controls/com.sun.javafx.scene.control.inputmap=ALL-UNNAMED --add-opens javafx.graphics/com.sun.javafx.iio=ALL-UNNAMED --add-opens javafx.graphics/com.sun.javafx.iio.common=ALL-UNNAMED --add-opens javafx.graphics/com.sun.javafx.css=ALL-UNNAMED --add-opens javafx.base/com.sun.javafx.runtime=ALL-UNNAMED --add-exports javafx.controls/com.sun.javafx.scene.control.behavior=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.scene.traversal=ALL-UNNAMED'
 
 grindvals $ARGS -Djava.library.path=$BASEDIR  -classpath $CLASSPATH:$BASEDIR/target/classes $@
-
-
-

--- a/bin/runWithLeakCheck
+++ b/bin/runWithLeakCheck
@@ -1,9 +1,9 @@
 #!/bin/sh -x
 
-BASEDIR=$(dirname $(dirname $(realpath $0)))
+BASEDIR=$(dirname "$(dirname "$(realpath "$0")")")
 
-CLASSPATH=$(cat $BASEDIR/class.path)
+CLASSPATH=$(cat "$BASEDIR"/class.path)
 
 ARGS='-ea --enable-preview --enable-native-access=arb4j --add-modules=javafx.graphics --add-reads javafx.graphics=ALL-UNNAMED --add-opens javafx.controls/com.sun.javafx.charts=ALL-UNNAMED --add-opens javafx.controls/com.sun.javafx.scene.control.inputmap=ALL-UNNAMED --add-opens javafx.graphics/com.sun.javafx.iio=ALL-UNNAMED --add-opens javafx.graphics/com.sun.javafx.iio.common=ALL-UNNAMED --add-opens javafx.graphics/com.sun.javafx.css=ALL-UNNAMED --add-opens javafx.base/com.sun.javafx.runtime=ALL-UNNAMED --add-exports javafx.controls/com.sun.javafx.scene.control.behavior=ALL-UNNAMED --add-exports javafx.graphics/com.sun.javafx.scene.traversal=ALL-UNNAMED'
 
-grindvals $ARGS -Djava.library.path=$BASEDIR  -classpath $CLASSPATH:$BASEDIR/target/classes $@
+grindvals $ARGS -Djava.library.path="$BASEDIR" -classpath "$CLASSPATH":"$BASEDIR"/target/classes "$@"

--- a/bin/runWithLeakCheck
+++ b/bin/runWithLeakCheck
@@ -1,6 +1,6 @@
 #!/bin/sh -x
 
-BASEDIR=$(dirname $(readlink -f $0))/..
+BASEDIR=$(dirname $(dirname $(readlink -f $0)))
 
 CLASSPATH=`cat $BASEDIR/class.path`
 

--- a/bin/runWithLeakCheck
+++ b/bin/runWithLeakCheck
@@ -1,6 +1,6 @@
 #!/bin/sh -x
 
-BASEDIR=$(dirname $(dirname $(readlink -f $0)))
+BASEDIR=$(dirname $(dirname $(realpath $0)))
 
 CLASSPATH=$(cat $BASEDIR/class.path)
 

--- a/bin/updateClasspath
+++ b/bin/updateClasspath
@@ -2,6 +2,6 @@
 
 fmdir=$(dirname "$(dirname "$(realpath "$0")")")
 
-cd "$fmdir"
+cd "$fmdir" || exit
 
 mvn dependency:build-classpath

--- a/bin/updateClasspath
+++ b/bin/updateClasspath
@@ -1,5 +1,7 @@
 #!/bin/sh
 
 FMDIR=$(dirname $(readlink -f $0))/..
+
 cd $FMDIR
+
 mvn dependency:build-classpath

--- a/bin/updateClasspath
+++ b/bin/updateClasspath
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-FMDIR=$(dirname $(dirname $(realpath $0)))
+FMDIR=$(dirname "$(dirname "$(realpath "$0")")")
 
-cd $FMDIR
+cd "$FMDIR"
 
 mvn dependency:build-classpath

--- a/bin/updateClasspath
+++ b/bin/updateClasspath
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-FMDIR=$(dirname $(readlink -f $0))/..
+FMDIR=$(dirname $(dirname $(readlink -f $0)))
 
 cd $FMDIR
 

--- a/bin/updateClasspath
+++ b/bin/updateClasspath
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-FMDIR=$(dirname "$(dirname "$(realpath "$0")")")
+fmdir=$(dirname "$(dirname "$(realpath "$0")")")
 
-cd "$FMDIR"
+cd "$fmdir"
 
 mvn dependency:build-classpath

--- a/bin/updateClasspath
+++ b/bin/updateClasspath
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-FMDIR=$(dirname $(dirname $(readlink -f $0)))
+FMDIR=$(dirname $(dirname $(realpath $0)))
 
 cd $FMDIR
 

--- a/bin/updateJavadocs
+++ b/bin/updateJavadocs
@@ -2,13 +2,13 @@
 
 fmdir=$(dirname "$(dirname "$(realpath "$0")")")
 
-cd "$fmdir"
+cd "$fmdir" || exit
 
 mvn javadoc:javadoc
 
 cp -vr target/site/apidocs/. ../arb4j-pages/
 
-cd ../arb4j-pages
+cd ../arb4j-pages || exit
 
 git add .
 

--- a/bin/updateJavadocs
+++ b/bin/updateJavadocs
@@ -1,6 +1,6 @@
 #!/bin/sh -x
 
-FMDIR=$(dirname $(readlink -f $0))/..
+FMDIR=$(dirname $(dirname $(readlink -f $0)))
 
 cd $FMDIR
 

--- a/bin/updateJavadocs
+++ b/bin/updateJavadocs
@@ -1,8 +1,8 @@
 #!/bin/sh -x
 
-FMDIR=$(dirname "$(dirname "$(realpath "$0")")")
+fmdir=$(dirname "$(dirname "$(realpath "$0")")")
 
-cd "$FMDIR"
+cd "$fmdir"
 
 mvn javadoc:javadoc
 

--- a/bin/updateJavadocs
+++ b/bin/updateJavadocs
@@ -6,7 +6,7 @@ cd "$fmdir" || exit
 
 mvn javadoc:javadoc
 
-cp -vr target/site/apidocs/. ../arb4j-pages/
+cp -R target/site/apidocs ../arb4j-pages/
 
 cd ../arb4j-pages || exit
 

--- a/bin/updateJavadocs
+++ b/bin/updateJavadocs
@@ -1,6 +1,6 @@
 #!/bin/sh -x
 
-FMDIR=$(dirname $(dirname $(readlink -f $0)))
+FMDIR=$(dirname $(dirname $(realpath $0)))
 
 cd $FMDIR
 

--- a/bin/updateJavadocs
+++ b/bin/updateJavadocs
@@ -1,8 +1,8 @@
 #!/bin/sh -x
 
-FMDIR=$(dirname $(dirname $(realpath $0)))
+FMDIR=$(dirname "$(dirname "$(realpath "$0")")")
 
-cd $FMDIR
+cd "$FMDIR"
 
 mvn javadoc:javadoc
 

--- a/bin/updateJavadocs
+++ b/bin/updateJavadocs
@@ -1,12 +1,17 @@
 #!/bin/sh -x
 
 FMDIR=$(dirname $(readlink -f $0))/..
+
 cd $FMDIR
+
 mvn javadoc:javadoc
+
 cp -vr target/site/apidocs/. ../arb4j-pages/
+
 cd ../arb4j-pages
+
 git add .
 
 git commit -m 'update javadocs'
-git push
 
+git push


### PR DESCRIPTION
After issue-117 branch is merged, make the other arb4j/bin/ scripts as stylish and portable as bin/gaw and bin/caw.

Warning: these scripts call some commands that imply undocumented dependencies, such as valgrind, mvn (Maven), and dict.