### PR TITLE
Fix NAryOperationNode.parseOperand() cursor corruption (#891)

### DIFF
--- a/src/main/java/arb/expressions/Expression.java
+++ b/src/main/java/arb/expressions/Expression.java
@@ -296,6 +296,20 @@ public class Expression<D, C, F extends Function<? extends D, ? extends C>> impl
 
   public char                                                previousCharacter;
 
+  public record CursorState(int position, char character, char previousCharacter) {}
+
+  public CursorState saveCursor()
+  {
+    return new CursorState(position, character, previousCharacter);
+  }
+
+  public void restoreCursor(CursorState state)
+  {
+    position          = state.position();
+    character         = state.character();
+    previousCharacter = state.previousCharacter();
+  }
+
   public boolean                                             recursive                        = false;
 
   private final HashMap<String, FunctionMapping<?, ?, ?>>    referencedFunctions              = new HashMap<>();

--- a/src/main/java/arb/expressions/nodes/nary/NAryOperationNode.java
+++ b/src/main/java/arb/expressions/nodes/nary/NAryOperationNode.java
@@ -17,6 +17,7 @@ import arb.*;
 import arb.Integer;
 import arb.exceptions.CompilerException;
 import arb.expressions.*;
+import arb.expressions.Expression.CursorState;
 import arb.expressions.Context;
 import arb.expressions.nodes.Node;
 import arb.expressions.nodes.VariableNode;
@@ -442,8 +443,9 @@ public class NAryOperationNode<D, R, F extends Function<? extends D, ? extends R
   {
     assert operandFunctionFieldName != null : "assignFieldNamesIfNecessary must be called before parseOperand";
 
-    String  paramName = expression.parseName();
-    boolean hasArrow  = false;
+    CursorState savedCursor = expression.saveCursor();
+    String      paramName   = expression.parseName();
+    boolean     hasArrow    = false;
     expression.skipSpaces();
 
     if (expression.character == '\u2794')
@@ -452,29 +454,23 @@ public class NAryOperationNode<D, R, F extends Function<? extends D, ? extends R
       hasArrow = true;
     }
 
-    operandExpression = new Expression<>(Integer.class, expression.coDomainType, Sequence.class);
-
     if (!hasArrow)
     {
-      expression.position -= paramName.length();
+      expression.restoreCursor(savedCursor);
     }
 
+    operandExpression                     = new Expression<>(Integer.class, expression.coDomainType, Sequence.class);
     operandExpression.continueParsingFrom(expression);
-
     operandExpression.upstreamExpression  = expression;
     operandExpression.context             = expression.context;
     operandExpression.independentVariable = null;
     operandExpression.clearIndeterminateVariables();
     operandExpression.className           = operandFunctionFieldName;
-
-    operandExpression.newVariableNode(paramName);
-    indexVariableFieldName = paramName;
-
-    operandExpression.rootNode = operandExpression.resolve();
+    indexVariableFieldName                = paramName;
+    operandExpression.rootNode            = operandExpression.resolve();
 
     expression.continueParsingFrom(operandExpression);
     operandExpression.updateStringRepresentation();
-
     registerOperand(operandFunctionFieldName, operandExpression);
     propagateContextVariablesToOperand();
   }


### PR DESCRIPTION
## Summary

Fixes #891 — cursor corruption in `NAryOperationNode.parseOperand()` on the `naryoperationOverhaul` branch.

### Root Cause
The parser state triple (`position`, `character`, `previousCharacter`) was corrupted by `expression.position -= paramName.length()`, which rewound `position` but left `character` and `previousCharacter` stale. The sub-expression parser then dispatched on a fabricated lookahead, producing a null `rootNode`, doubled sigil output, and runtime `NoSuchFieldError`.

### Changes

**`Expression.java`**:
- Added nested `CursorState` record capturing `position`, `character`, `previousCharacter`
- Added `saveCursor()` and `restoreCursor(CursorState)` methods

**`NAryOperationNode.java`**:
- Save cursor before `parseName()`, restore it instead of manual position arithmetic
- Removed orphaned `operandExpression.newVariableNode(paramName)` call
- Retained `indexVariableFieldName = paramName`