### PR TITLE
Fix NPE in RiemannSiegelThetaFunction.evaluate() when order < 2

### DIFF
--- a/src/main/java/arb/functions/real/RiemannSiegelThetaFunction.java
+++ b/src/main/java/arb/functions/real/RiemannSiegelThetaFunction.java
@@ -47,11 +47,12 @@ public class RiemannSiegelThetaFunction implements
   @Override
   public Real evaluate(Real t, int order, int bits, Real result)
   {
-    try ( RealPolynomial h = new RealPolynomial(order); RealPolynomial out = new RealPolynomial(order))
+    int hLen = Math.max(order, 2);
+    try ( RealPolynomial h = new RealPolynomial(hLen); RealPolynomial out = new RealPolynomial(order))
     {
 
-      h.fitLength(order);
-      h.setLength(order);
+      h.fitLength(hLen);
+      h.setLength(hLen);
 
       // h(x) = t + x
       h.get(0).set(t); // constant term = t*x^0=t*1=t


### PR DESCRIPTION
## Summary
- **Fixes #942**: `RiemannSiegelThetaFunction.evaluate()` throws `NullPointerException` when called with `order < 2` (e.g., via `eval(double)` which passes `order=1`)
- **Root cause**: The input polynomial `h(x) = t + x` always needs 2 coefficients (constant term `t` and linear term `1`), but the allocation used `order` directly. When `order=1`, only 1 coefficient was allocated, so `h.get(1)` returned `null` and `.one()` threw NPE.
- **Fix**: Use `Math.max(order, 2)` for the input polynomial `h` allocation to ensure both coefficients are always accessible, while keeping the output polynomial sized at `order` as intended.

## Test plan
- [ ] `new RiemannSiegelThetaFunction().eval(2.3)` no longer throws NPE
- [ ] `RiemannSiegelThetaFunction.main()` (which uses `order=20`) continues to work correctly
- [ ] `mvn compile` passes cleanly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)